### PR TITLE
last comma in the json object doesn't parse.

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Then issue `:CocConfig` and add the following to your Coc config file.
     "initializationOptions": {
       "languageServerHaskell": {
       }
-    },
+    }
   }
 }
 ```


### PR DESCRIPTION
Some JSON parsing tools won't accept the last comma in an object.